### PR TITLE
Get dockerhub auth from context instead of project env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2
 workflows:
+  version: 2
   dockerhub-auth:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,10 @@
 version: 2
+workflows:
+  dockerhub-auth:
+    jobs:
+      - build:
+          context: dockerhub
+
 jobs:
   build:
     machine: true
@@ -88,7 +94,7 @@ jobs:
       - run:
           name: Building & Releasing docker images
           command: |
-            echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USER --password-stdin
+            echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
 
             if [[ $CIRCLE_BRANCH = 'develop' ]]
             then


### PR DESCRIPTION
We are changing Docker Hub auth right now which will effect all the repositories using the current credentials. Moving this to the org wide "context" to avoid changing per repo in the future and keep it central. 
TODO
- Remove project env vars config on CircleCI
- Test